### PR TITLE
Compatibilidade com as últimas versões do Magento CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 ## Testado em Magento
 
-`1.6.2.0`, `1.7.0.2` e `1.8.1.0`
-
+`1.6.2.0`, `1.7.0.2`, `1.8.1.0` e `1.9.0.1`
 
 ## Instalando por Magento Connect
 

--- a/app/code/community/PedroTeixeira/Correios/etc/system.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/system.xml
@@ -168,7 +168,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>
-                                <![CDATA[Ao habilitar essa funcionalidade cada produto será validado seguindo a regra de dimensões dos Correios.<br />A regra pode ser encontrada <a href="http://www.correios.com.br/encomendas/prazo/Formato.cfm" target="_blank">nesse link</a>.]]></comment>
+                                <![CDATA[Ao habilitar essa funcionalidade cada produto será validado seguindo a regra de dimensões dos Correios.<br />A regra pode ser encontrada <a href="http://www2.correios.com.br/sistemas/precosprazos/Formato.cfm" target="_blank">nesse link</a>.]]></comment>
                         </check_dimensions>
                         <altura_padrao translate="label">
                             <label>Altura Padrão (cm)</label>


### PR DESCRIPTION
Validar compatibilidade com `1.6.2.0`, `1.7.0.2`, `1.8.1.0` e `1.9.0.1`.
