### PR TITLE
Usar atributo para setar o carrier name e passar o encoding para htmlentities

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -607,7 +607,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
                 );
 
                 if ($description !== '') {
-                    $track['activity'] = $matches[3] . ' - ' . htmlentities($description);
+                    $track['activity'] = $matches[3] . ' - ' . htmlentities($description, ENT_IGNORE, "ISO-8859-1");
                 }
 
                 $progress[] = $track;


### PR DESCRIPTION
setCarrier já está setado acima e da forma correta, setar ISO-8859-1 na descrição para que possa ser passada para entidade html.

Veja: From PHP 5.4.0, UTF-8 is the default. PHP prior to 5.4.0, ISO-8859-1 is used as the default. (http://php.net/manual/en/function.htmlentities.php)
