### PR TITLE
Melhorias no cálculo de frete.

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -802,6 +802,10 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
                 $prodPostMethods = explode(',', $product->getData('postmethods'));
                 $intersection    = array_intersect($prodPostMethods, $intersection);
             }
+			
+			if(count($intersection) == 0) {
+				return false;
+            }
 
             $this->_postMethodsExplode = $intersection;
             $this->_postMethods        = implode(',', $intersection);

--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -799,13 +799,13 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
             $intersection = $this->_postMethodsExplode;
             foreach ($items as $item) {
                 $product         = Mage::getModel('catalog/product')->load($item->getProductId());
+				if(count($product->getData('postmethods')) == 0) {
+                    continue;
+                }
                 $prodPostMethods = explode(',', $product->getData('postmethods'));
                 $intersection    = array_intersect($prodPostMethods, $intersection);
             }
 			
-			if(count($intersection) == 0) {
-				return false;
-            }
 
             $this->_postMethodsExplode = $intersection;
             $this->_postMethods        = implode(',', $intersection);


### PR DESCRIPTION
Reparado o erro de mensagem de módulo fora do ar ao Habilitar Filtro de Serviços por Produto.
Erro ocorria ao habilitar a opção acima e um produto específico não estava com alguma opção de frete selecionada.