### PR TITLE
Customização para cálculo do tempo de fabricação

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -372,6 +372,7 @@
                 <free_method>40010</free_method>
                 <weight_type>kg</weight_type>
                 <add_prazo>0</add_prazo>
+                <work_time>8</work_time>
                 <showmethod>1</showmethod>
                 <filter_by_item>0</filter_by_item>
                 <split_pack>1</split_pack>

--- a/app/code/community/PedroTeixeira/Correios/etc/system.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/system.xml
@@ -236,6 +236,15 @@
                             <show_in_store>1</show_in_store>
                             <comment>Adicionará mais dias aos prazos fornecidos pelos Correios.</comment>
                         </add_prazo>
+                        <work_time translate="label">
+                            <label>Tempo trabalho no dia (horas)</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>175</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Tempo em horas que os funcionários trabalham em um dia.</comment>
+                        </work_time>
                         <correioserror translate="label">
                             <label>Mensagem que Exibe os Erros dos Correios</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
Olá @pedro-teixeira e todos os colaboradores...

Sou novo no Magento e baixei o seu seu módulo, como eu precisava dessa alteração resolvi fazer e envio esse PR para você analisar e quem sabe colocar em uma futura versão do módulo, para mim esta funcionando.

É o seguinte, precisava que no cálculo dos dias do correios fosse adicionado o tempo de fabricação dos meus produtos. Para isto criei um atributo "Tempo de fabricação" (código: deadline) e para todos os meus produtos que possuem tempo de fabricação, adiciono a quantidade média de horas que é necessário para fabricar cada item. No cálculo dos correios faço o somatório dessas horas e divido pela quantidade de horas por dia trabalhadas por meus funcionários, para isto adicionei nas configurações do módulo um campo "work_time".

Mesmo se não houver o atributo não há erro porque faço o casting para float, que dá zero se não houver o atributo.

Se houver algo que possa melhorar posso alterar. :)

