### PR TITLE
Fix para frete com desconto/grátis em áreas com restrição de entrega

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -114,7 +114,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
 
         $this->_filterMethodByItemRestriction();
         if ($this->_getQuotes()->getError()) {
-            //Fix to allow discounts on delivery areas with restrictions for
+            //Fix to allow discounts on delivery areas with restrictions
             $this->_updateFreeMethodQuote($request);
             return $this->_result;
         }

--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -113,12 +113,10 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
         }
 
         $this->_filterMethodByItemRestriction();
-        if ($this->_getQuotes()->getError()) {
-            //Fix to allow discounts on delivery areas with restrictions
-            $this->_updateFreeMethodQuote($request);
-            return $this->_result;
-        }
 
+        //Show Quotes
+        $this->_getQuotes();
+        
         // Use descont codes
         $this->_updateFreeMethodQuote($request);
 

--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -114,6 +114,8 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
 
         $this->_filterMethodByItemRestriction();
         if ($this->_getQuotes()->getError()) {
+            //Fix to allow discounts on delivery areas with restrictions for
+            $this->_updateFreeMethodQuote($request);
             return $this->_result;
         }
 


### PR DESCRIPTION
Correção de bug ao utilizar promoção de frete grátis em áreas com restrição de entrega. 
Durante testes na versão 4.5.0, se o cliente utilizar um cupom/regra para permitir frete grátis, e se, este cliente tiver em área de restrição, não é dado desconto. O desconto aparece apenas em áreas sem restrições.
Para fins de testes, este foi um dos ceps que utilizei para testar 04843-640 (com restrição de entrega)