### PR TITLE
Monitoramento Automático da Encomenda, e Atualização do Status da Entrega

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Observer.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Observer.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2015 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+class PedroTeixeira_Correios_Model_Observer
+{
+    /**
+     * Look for shipped trackings, and send notifications if available and enabled
+     * 
+     * @return string
+     */
+    public function sroTrackingJob()
+    {
+        $count = 0;
+        /* @var $sro PedroTeixeira_Correios_Model_Sro */
+        $sro = Mage::getModel('pedroteixeira_correios/sro');
+        $collection = $sro->getShippedTracks();
+        foreach ($collection as $track) {
+            /* @var $track Mage_Sales_Model_Order_Shipment_Track */
+            if ($sro->request($track->getNumber())) {
+                $savedId = $track->getDescription();
+                $eventId = $sro->getEventId();
+                if ($eventId != $savedId) {
+                    $track->setDescription($eventId)->save();
+                    $track->getShipment()->getOrder()
+                        ->setStatus($sro->getStatus())
+                        ->save();
+                    $track->getShipment()
+                        ->addComment($sro->getComment(), $sro->isNotify(), true)
+                        ->sendUpdateEmail($sro->isNotify(), $sro->getEmailComment())
+                        ->save();
+                    $count++;
+                }
+            }
+        }
+        return "Tracked {$count} objects of {$collection->getSize()}.";
+    }
+}

--- a/app/code/community/PedroTeixeira/Correios/Model/Sro.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Sro.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2015 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+class PedroTeixeira_Correios_Model_Sro extends Varien_Object
+{
+    const CARRIER_CODE = 'pedroteixeira_correios';
+    const ORDER_SHIPPED_STATUS = 'complete_shipped';
+    const ORDER_WARNED_STATUS = 'complete_warned';
+
+    /**
+     * Request response
+     * 
+     * @var SimpleXMLElement
+     */
+    protected $_xml = null;
+    
+    /**
+     * Load all opened tracks from database.
+     * Filter tracks only with complete order state, and shipped status.
+     * 
+     * @return Mage_Sales_Model_Resource_Order_Shipment_Track_Collection
+     */
+    public function getShippedTracks()
+    {
+        $trackTable = 'main_table';
+        $orderTable = Mage::getModel('sales/order')->getCollection()->getResource()->getTable('sales/order');
+        
+        /* @var $collection Mage_Sales_Model_Resource_Order_Shipment_Track_Collection */
+        $collection = Mage::getModel('sales/order_shipment_track')->getCollection();
+        $collection->getSelect()->join($orderTable, "{$trackTable}.order_id = {$orderTable}.entity_id", array());
+        $collection
+            ->addFieldToFilter("{$trackTable}.carrier_code", self::CARRIER_CODE)
+            ->addFieldToFilter("{$orderTable}.state", Mage_Sales_Model_Order::STATE_COMPLETE)
+            ->addFieldToFilter("{$orderTable}.status", array('neq' => Mage_Sales_Model_Order::STATE_COMPLETE));
+        return $collection;
+    }
+    
+    /**
+     * Load XML response from Correios
+     * 
+     * @param string $number Tracking Code
+     * 
+     * @throws Zend_Http_Client_Adapter_Exception
+     * 
+     * @link http://www.correios.com.br/para-voce/correios-de-a-a-z/pdf/rastreamento-de-objetos/
+     * Manual_SROXML_28fev14.pdf
+     * 
+     * @return SimpleXMLElement
+     */
+    public function request($number)
+    {
+        $client = new Zend_Http_Client($this->getConfigData("url_sro_correios"));
+        $client->setParameterPost('Usuario', $this->getConfigData('sro_username'));
+        $client->setParameterPost('Senha', $this->getConfigData('sro_password'));
+        $client->setParameterPost('Tipo', $this->getConfigData('sro_type'));
+        $client->setParameterPost('Resultado', $this->getConfigData('sro_result'));
+        $client->setParameterPost('Objetos', $number);
+        try {
+            $response = $client->request(Zend_Http_Client::POST)->getBody();
+            if (empty($response)) {
+                throw new Zend_Http_Client_Adapter_Exception("Empty response");
+            }
+            libxml_use_internal_errors(true);
+            $this->_xml = simplexml_load_string($response);
+            if (!$this->_xml || !isset($this->_xml->objeto)) {
+                throw new Zend_Http_Client_Adapter_Exception("Invalid XML");
+            }
+        } catch (Zend_Http_Exception $e) {
+            Mage::log("{$e->getMessage()}");
+            Mage::log("TRACKING: {$number}");
+            Mage::log("RESPONSE: {$response}");
+            return false;
+        }
+        return $this;
+    }
+    
+    /**
+     * Retrieve config value by path
+     * 
+     * @param string $path Variable Path
+     * 
+     * @return string
+     */
+    public function getConfigData($path)
+    {
+        return Mage::getStoreConfig("carriers/" . self::CARRIER_CODE . "/{$path}");
+    }
+    
+    /**
+     * Returns a Shipping comment message
+     * 
+     * @return string
+     */
+    public function getComment()
+    {
+        $code = $this->_xml->objeto->numero;
+        $evento = $this->_xml->objeto->evento;
+        $msg = array();
+        $msg[] = $code;
+        $msg[] = "{$evento->cidade}/{$evento->uf}";
+        $msg[] = $evento->descricao;
+        if (isset($evento->destino) && isset($evento->destino->local)) {
+            $last = count($msg) - 1;
+            $msg[$last].= " para {$evento->destino->cidade}/{$evento->destino->uf}";
+        }
+        if (isset($evento->recebedor) && !empty(trim($evento->recebedor))) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Recebedor: %s', $evento->recebedor);
+        }
+        if (isset($evento->comentario) && !empty(trim($evento->comentario))) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Comentário: %s', $evento->comentario);
+        }
+        $msg[] = Mage::helper('pedroteixeira_correios')->__('Evento: %s', "{$evento->tipo}/{$evento->status}");
+        return implode(' | ', $msg);
+    }
+    
+    /**
+     * Returns an Update Shipping e-mail comment
+     * 
+     * @return string
+     */
+    public function getEmailComment()
+    {
+        $trackUrl = $this->getConfigData('url_tracking');
+        $code = $this->_xml->objeto->numero;
+        $evento = $this->_xml->objeto->evento;
+        $htmlAnchor = "<a href=\"{$trackUrl}?P_LINGUA=001&P_TIPO=001&P_COD_UNI={$code}\">{$code}</a>";
+        $msg = array();
+        $msg[] = Mage::helper('pedroteixeira_correios')->__('Rastreador: %s', $htmlAnchor);
+        $msg[] = Mage::helper('pedroteixeira_correios')->__('Local: %s', "{$evento->cidade}/{$evento->uf}");
+        $msg[] = Mage::helper('pedroteixeira_correios')->__('Situação: %s', $evento->descricao);
+        if (isset($evento->recebedor) && !empty(trim($evento->recebedor))) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Recebedor: %s', $evento->recebedor);
+        }
+        if (isset($evento->comentario) && !empty(trim($evento->comentario))) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Comentário: %s', $evento->comentario);
+        }
+        if (isset($evento->destino)) {
+            $destino = $evento->destino;
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Destino: %s', "{$destino->cidade}/{$destino->uf}");
+        }
+        return implode('<br />', $msg);
+    }
+    
+    /**
+     * Check the event type
+     * 
+     * @param string $mode Event Type Mode
+     * 
+     * @return boolean
+     */
+    public function validate($mode)
+    {
+        $isValid = false;
+        $evento = $this->_xml->objeto->evento;
+        $hashTypes = explode(',', $this->getConfigData("sro_event_type_{$mode}"));
+        if (in_array($evento->tipo, $hashTypes)) {
+            $type = strtolower($evento->tipo);
+            $hashStatus = explode(',', $this->getConfigData("sro_event_status_{$mode}_{$type}"));
+            $isValid = in_array((int) $evento->status, $hashStatus);
+        }
+        return $isValid;
+    }
+    
+    /**
+     * Track Description field are now being used to save the event id.
+     * Event Id is a simple key to identify the last carrier event.
+     * 
+     * @return string
+     */
+    public function getEventId()
+    {
+        $code = $this->_xml->objeto->numero;
+        $date = $this->_xml->objeto->evento->data;
+        $hour = $this->_xml->objeto->evento->hora;
+        $type = $this->_xml->objeto->evento->tipo;
+        return "{$code}::{$date}{$hour}::{$type}";
+    }
+    
+    /**
+     * Check whether event notify is enabled or not
+     * 
+     * @return boolean
+     */
+    public function isNotify()
+    {
+        return $this->validate('notify');
+    }
+    
+    /**
+     * Load order status based on event checking
+     * 
+     * @return string
+     */
+    public function getStatus()
+    {
+        $status = self::ORDER_SHIPPED_STATUS;
+        if ($this->validate('warn')) {
+            $status = self::ORDER_WARNED_STATUS;
+        }
+        if ($this->validate('last')) {
+            $status = Mage_Sales_Model_Order::STATE_COMPLETE;
+        }
+        return $status;
+    }
+}

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -778,18 +778,6 @@
             </pedroteixeira_correios>
         </carriers>
     </default>
-    <adminhtml>
-    	<events>
-    		<!--sales_order_shipment_track_save_before>
-    			<observers>
-    				<correios_sales_order_shipment_track_save_before>
-    					<class>PedroTeixeira_Correios_Model_Observer</class>
-    					<method>saveTrackBefore</method>
-    				</correios_sales_order_shipment_track_save_before>
-    			</observers>
-    		</sales_order_shipment_track_save_before-->
-    	</events>
-    </adminhtml>
     <crontab>
         <jobs>
             <correios_status_check>

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <PedroTeixeira_Correios>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
             <depends>
                 <Mage_Shipping/>
             </depends>
@@ -403,6 +403,37 @@
                 <contrato_codes>40096,81019,41068,41300</contrato_codes>
                 <url_ws_correios>http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx</url_ws_correios>
 
+                <!-- SRO XML -->
+                <sro_username>ECT</sro_username>
+                <sro_password>SRO</sro_password>
+                <sro_type>L</sro_type>
+                <sro_result>U</sro_result>
+                
+                <sro_event_type_notify>BDE,BDI,BDR,FC,LDI,OEC</sro_event_type_notify>
+                <sro_event_status_notify_bde>0,1,2,7,20,24,25,34,45,54,55</sro_event_status_notify_bde>
+                <sro_event_status_notify_bdi>0,1,2,7,20,24,25,34,45,54,55</sro_event_status_notify_bdi>
+                <sro_event_status_notify_bdr>0,1,2,7,20,24,25,34,45,54,55</sro_event_status_notify_bdr>
+                <sro_event_status_notify_fc>4,7</sro_event_status_notify_fc>
+                <sro_event_status_notify_ldi>0,1,2,3,14</sro_event_status_notify_ldi>
+                <sro_event_status_notify_oec>0,1</sro_event_status_notify_oec>
+                
+                <sro_event_type_warn>BDE,BDI,BDR,FC,LDI,OEC</sro_event_type_warn>
+                <sro_event_status_warn_bde>3,4,5,6,7,8,9,10,12,19,21,22,23,26,28,33,34,35,36,37,38,40,41,42,43,48,49,50,51,52,54,55,56,57,58,59,69</sro_event_status_warn_bde>
+                <sro_event_status_warn_bdi>3,4,5,6,7,8,9,10,12,19,21,22,23,26,28,33,34,35,36,37,38,40,41,42,43,48,49,50,51,52,54,55,56,57,58,59,69</sro_event_status_warn_bdi>
+                <sro_event_status_warn_bdr>3,4,5,6,7,8,9,10,12,19,21,22,23,26,28,33,34,35,36,37,38,40,41,42,43,48,49,50,51,52,54,55,56,57,58,59,69</sro_event_status_warn_bdr>
+                <sro_event_status_warn_blq>1</sro_event_status_warn_blq>
+                <sro_event_status_warn_ldi>0,1,3,14</sro_event_status_warn_ldi>
+                <sro_event_status_warn_fc>1,4,5</sro_event_status_warn_fc>
+                <sro_event_status_warn_idc>1,2,3,4,5,6,7</sro_event_status_warn_idc>
+                
+                <sro_event_type_last>BDE,BDI,BDR</sro_event_type_last>
+                <sro_event_status_last_bde>0,1</sro_event_status_last_bde>
+                <sro_event_status_last_bdi>0,1</sro_event_status_last_bdi>
+                <sro_event_status_last_bdr>0,1</sro_event_status_last_bdr>
+                
+                <url_sro_correios>http://websro.correios.com.br/sro_bin/sroii_xml.eventos</url_sro_correios>
+                <url_tracking>http://websro.correios.com.br/sro_bin/txect01$.QueryList</url_tracking>
+
                 <!-- CACHE -->
                 <pattern_nocache><![CDATA[/<Erro>(-2|-3|-5|-6|-7|-8|-9|-10|-11|-12|-13|-14|-15|-16|-17|-18|-20|-22|-23|-24|-25|-26|-27|-28|-29|-30|-31|-32|-33|-34|-35|-36|-37|-38|-39|-40|-41|-42|-43|-44|-45|-888|006|007|009|010|011|7|99)<\/Erro>/]]></pattern_nocache>
                 <cache_timeout>31536000</cache_timeout>
@@ -747,4 +778,28 @@
             </pedroteixeira_correios>
         </carriers>
     </default>
+    <adminhtml>
+    	<events>
+    		<!--sales_order_shipment_track_save_before>
+    			<observers>
+    				<correios_sales_order_shipment_track_save_before>
+    					<class>PedroTeixeira_Correios_Model_Observer</class>
+    					<method>saveTrackBefore</method>
+    				</correios_sales_order_shipment_track_save_before>
+    			</observers>
+    		</sales_order_shipment_track_save_before-->
+    	</events>
+    </adminhtml>
+    <crontab>
+        <jobs>
+            <correios_status_check>
+                <schedule>
+                    <cron_expr>*/15 * * * *</cron_expr>
+                </schedule>
+                <run>
+                    <model>pedroteixeira_correios/observer::sroTrackingJob</model>
+                </run>
+            </correios_status_check>
+        </jobs>
+    </crontab>
 </config>

--- a/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/install-4.6.0.php
+++ b/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/install-4.6.0.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2015 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+
+/** @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+$installer->startSetup();
+
+$status = Mage::getModel('sales/order_status');
+$status->setStatus(PedroTeixeira_Correios_Model_Sro::ORDER_SHIPPED_STATUS)
+    ->setLabel('Pedido em Transporte')
+    ->assignState(Mage_Sales_Model_Order::STATE_COMPLETE)
+    ->save();
+
+$status = Mage::getModel('sales/order_status');
+$status->setStatus(PedroTeixeira_Correios_Model_Sro::ORDER_WARNED_STATUS)
+    ->setLabel('Dificuldade de Entrega')
+    ->assignState(Mage_Sales_Model_Order::STATE_COMPLETE)
+    ->save();
+
+/* @var $installer Mage_Catalog_Model_Resource_Eav_Mysql4_Setup */
+$setup = new Mage_Eav_Model_Entity_Setup('core_setup');
+
+// Add volume to prduct attribute set
+$codigo = 'volume_comprimento';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Comprimento (cm)',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Comprimento da embalagem do produto (Para cálculo dos Correios)'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+// Add volume to prduct attribute set
+$codigo = 'volume_altura';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Altura (cm)',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Altura da embalagem do produto (Para cálculo dos Correios)'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+// Add volume to prduct attribute set
+$codigo = 'volume_largura';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Largura (cm)',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Largura da embalagem do produto (Para cálculo dos Correios)'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$codigo = 'postmethods';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Serviços de Entrega',
+    'type'     => 'text',
+    'input'    => 'multiselect',
+    'source'   => 'pedroteixeira_correios/source_postMethods',
+    'backend'  => 'eav/entity_attribute_backend_array',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Selecione os serviços apropriados para o produto.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$codigo = 'fit_size';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Diferença do Encaixe (cm)',
+    'type'     => 'varchar',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Exemplo: Se 1 item mede 10cm de altura, e 2 itens encaixados medem 11cm. A diferença é de 1cm.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$codigo = 'posting_days';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Prazo de Postagem',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'O prazo total é o Prazo dos Correios acrescido do maior Prazo de Postagem dos produtos no carrinho.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$installer->endSetup();

--- a/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.5.0-4.6.0.php
+++ b/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.5.0-4.6.0.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2015 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+
+/** @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+$installer->startSetup();
+
+$status = Mage::getModel('sales/order_status');
+$status->setStatus(PedroTeixeira_Correios_Model_Sro::ORDER_SHIPPED_STATUS)
+    ->setLabel('Pedido em Transporte')
+    ->assignState(Mage_Sales_Model_Order::STATE_COMPLETE)
+    ->save();
+
+$status = Mage::getModel('sales/order_status');
+$status->setStatus(PedroTeixeira_Correios_Model_Sro::ORDER_WARNED_STATUS)
+    ->setLabel('Dificuldade de Entrega')
+    ->assignState(Mage_Sales_Model_Order::STATE_COMPLETE)
+    ->save();
+
+$installer->endSetup();


### PR DESCRIPTION
Closes #53 
Apesar de postar somente agora, uso esse recurso desde o início de Maio/2015.

Esta PR tem por objetivo monitorar, de forma automatizada, o andamento da encomenda junto aos Correios.
Ao cadastrar um rastreio, o pedido vai para o estado _complete_ (por padrão Transação Concluída). Se o logista deseja o monitoramento automatizado das encomendas, precisa apenas alterar a situação para _Pedido em Transporte_.
A loja irá consultar os Correios, de forma sistemática. E registrará, no _Histórico da Entrega_, qualquer mudança de _status_ da encomenda.
![image](https://cloud.githubusercontent.com/assets/3688798/8786710/22b4af4e-2f06-11e5-9a46-9a18c7345785.png)

Embora visível no frontend, o cliente é notificado via e-mail somente caso necessário.

Em situações incomuns (ex.: aguardando retirada; objeto com atraso), o pedido é automaticamente alterado para _Dificuldade de Entrega_, para que o logista possa tomar as devidas providências, antes de contatar o cliente.

Após detectar a entrega, o pedido vai para _Transação Concluída_, e não é mais monitorado.
Observações:
* Para interromper o monitoramento basta alterar o pedido para _Transação Concluída_.
* Não é recomendado monitorar 2 objetos em 1 único registro de entrega.
* Todos os eventos de notificação, mudança de _status_, etc, são passíveis de alteração, através do arquivo de configurações deste módulo.
* O ambiente SRO XML disponibilizado pela ECT é aberto para consultas. Mas o logista pode utilizar seu usuário/senha particulares se preferir. Basta alterar as variáveis `sro_username` e `sro_password`.