### PR TITLE
Added Validation to null postcode in cart update.

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -205,6 +205,10 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
             Mage::log('pedroteixeira_correios: From ZIP Code Error');
             return false;
         }
+        
+        if (!trim($this->_toZip)) {
+            return false;
+        }
 
         $this->_result = Mage::getModel('shipping/rate_result');
         $this->_packageValue = $request->getBaseCurrency()->convert(


### PR DESCRIPTION
I have been working in another feature in Checkout cart and I received this error:
```
==> var/log/system.log <==
2015-08-18T14:05:57+00:00 DEBUG (7): pedroteixeira_correios [83]: Invalid Zip Code
```
This validation resolve this warning.