### PR TITLE
Correção na utilização da função empty()

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Sro.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Sro.php
@@ -113,10 +113,12 @@ class PedroTeixeira_Correios_Model_Sro extends Varien_Object
             $last = count($msg) - 1;
             $msg[$last].= " para {$evento->destino->cidade}/{$evento->destino->uf}";
         }
-        if (isset($evento->recebedor) && !empty(trim($evento->recebedor))) {
+        $recebedor = trim($evento->recebedor);
+        if (isset($evento->recebedor) && !empty($recebedor)) {
             $msg[] = Mage::helper('pedroteixeira_correios')->__('Recebedor: %s', $evento->recebedor);
         }
-        if (isset($evento->comentario) && !empty(trim($evento->comentario))) {
+        $comentario = trim($evento->comentario);
+        if (isset($evento->comentario) && !empty($comentario)) {
             $msg[] = Mage::helper('pedroteixeira_correios')->__('Comentário: %s', $evento->comentario);
         }
         $msg[] = Mage::helper('pedroteixeira_correios')->__('Evento: %s', "{$evento->tipo}/{$evento->status}");
@@ -138,11 +140,14 @@ class PedroTeixeira_Correios_Model_Sro extends Varien_Object
         $msg[] = Mage::helper('pedroteixeira_correios')->__('Rastreador: %s', $htmlAnchor);
         $msg[] = Mage::helper('pedroteixeira_correios')->__('Local: %s', "{$evento->cidade}/{$evento->uf}");
         $msg[] = Mage::helper('pedroteixeira_correios')->__('Situação: %s', $evento->descricao);
-        if (isset($evento->recebedor) && !empty(trim($evento->recebedor))) {
-            $msg[] = Mage::helper('pedroteixeira_correios')->__('Recebedor: %s', $evento->recebedor);
+        
+        $recebedor = trim($evento->recebedor);
+        if (isset($recebedor) && !empty($recebedor)) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Recebedor: %s', $recebedor);
         }
-        if (isset($evento->comentario) && !empty(trim($evento->comentario))) {
-            $msg[] = Mage::helper('pedroteixeira_correios')->__('Comentário: %s', $evento->comentario);
+        $comentario = trim($evento->comentario);
+        if (isset($comentario) && !empty($comentario)) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Comentário: %s', $comentario);
         }
         if (isset($evento->destino)) {
             $destino = $evento->destino;

--- a/app/code/community/PedroTeixeira/Correios/Model/Sro.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Sro.php
@@ -114,12 +114,12 @@ class PedroTeixeira_Correios_Model_Sro extends Varien_Object
             $msg[$last].= " para {$evento->destino->cidade}/{$evento->destino->uf}";
         }
         $recebedor = trim($evento->recebedor);
-        if (isset($evento->recebedor) && !empty($recebedor)) {
-            $msg[] = Mage::helper('pedroteixeira_correios')->__('Recebedor: %s', $evento->recebedor);
+        if (isset($recebedor) && !empty($recebedor)) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Recebedor: %s', $recebedor);
         }
         $comentario = trim($evento->comentario);
-        if (isset($evento->comentario) && !empty($comentario)) {
-            $msg[] = Mage::helper('pedroteixeira_correios')->__('Comentário: %s', $evento->comentario);
+        if (isset($comentario) && !empty($comentario)) {
+            $msg[] = Mage::helper('pedroteixeira_correios')->__('Comentário: %s', $comentario);
         }
         $msg[] = Mage::helper('pedroteixeira_correios')->__('Evento: %s', "{$evento->tipo}/{$evento->status}");
         return implode(' | ', $msg);


### PR DESCRIPTION
A função empty() somente verifica variáveis, qualquer outra coisa então irá resultar em um parse error. Em outras palavras, o seguinte trecho não funciona: empty(trim($name)).

Testei em uma instancia com PHP 5.3 e o erro aconteceu.
Referência: http://php.net/manual/pt_BR/function.empty.php

Closes #119