### PR TITLE
Correção para Warning: Invalid argument supplied for foreach

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -757,6 +757,9 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
     protected function _addPostMethods($cServico)
     {
         $addMethods = $this->getConfigData("add_postmethods");
+        if (empty($addMethods) || !is_array($addMethods)) {
+            return $cServico;
+        }
         foreach ($addMethods as $configData) {
             $isValid = true;
             $isValid &= $this->_packageWeight >= $configData['from']['weight'];


### PR DESCRIPTION
Closes #107, #122, #126

Corrige a mensagem de alerta _Warning: Invalid argument supplied for foreach_, e a funcionalidade de adição e alteração de novos métodos de postagem.