### PR TITLE
Fix noservices error

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -114,6 +114,9 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
 
         $this->_filterMethodByItemRestriction();
 
+        if (empty($this->_postMethods)) {
+            return false;
+        }
         //Show Quotes
         $this->_getQuotes();
         


### PR DESCRIPTION
Closes #123 
O erro 500 da issue estava relacionado ao envio da requisição, sem nenhum código de serviço postal.
O carrinho ficava inutilizado, mesmo havendo outras opções de frete.
A validação adicionada descarta o método de entrega, sem gerar erro 500.