### PR TITLE
Corrige Recoverable Error e Soap Error

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -623,7 +623,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
      * 
      * @return array
      */
-    protected function _getTrackingProgressDetails(SimpleXMLElement $evento, $isDelivered=false)
+    protected function _getTrackingProgressDetails($evento, $isDelivered=false)
     {
         $date = new Zend_Date($evento->data, 'dd/MM/YYYY', new Zend_Locale('pt_BR'));
         $track = array(

--- a/app/code/community/PedroTeixeira/Correios/Model/Sro.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Sro.php
@@ -79,6 +79,7 @@ class PedroTeixeira_Correios_Model_Sro extends Varien_Object
             $this->_xml = $response->return;
         } catch (Exception $e) {
             Mage::log("Soap Error: {$e->getMessage()}");
+            return false;
         }
         return $this;
     }


### PR DESCRIPTION
closes #162 

1. Corrige o tratamento do erro Soap com os Correios:
    * Could not connect to host
    * Error Fetching http headers
    * Gateway Timeout
    * SOAP-ERROR: Parsing WSDL
    * SOAP-ERROR: Parsing Schema

    Crítico: Alguns desses erros podem encaminhar e-mails para os destinos errados.
    Após a correção, o erro pode aparecer novamente no log, mas estará sendo tratado, o que não ocorria antes.

2. Corrige o _Recoverable Error_: Erro de tipagem. Após a correção o erro não aparece mais no log.

Como já deixei claro em outras PRs, tenho pouco tempo pra colaborar. Se puderem testar e dar um feedback, para o @pedro-teixeira não ficar no escuro...