### PR TITLE
Adicionada opção de configurar o monitoramento das encomendas

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Observer.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Observer.php
@@ -23,6 +23,10 @@ class PedroTeixeira_Correios_Model_Observer
         $count = 0;
         /* @var $sro PedroTeixeira_Correios_Model_Sro */
         $sro = Mage::getModel('pedroteixeira_correios/sro');
+        if ($sro->getConfigData('sro_tracking_job') == 0) {
+            return "SRO Tracking Job disabled.";
+        }
+        
         $collection = $sro->getShippedTracks();
         foreach ($collection as $track) {
             /* @var $track Mage_Sales_Model_Order_Shipment_Track */

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -417,6 +417,7 @@
                 <url_ws_correios>http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx</url_ws_correios>
 
                 <!-- SRO XML -->
+                <sro_tracking_job>0</sro_tracking_job>
                 <sro_username>ECT</sro_username>
                 <sro_password>SRO</sro_password>
                 <sro_type>L</sro_type>

--- a/app/code/community/PedroTeixeira/Correios/etc/system.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/system.xml
@@ -343,10 +343,20 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </show_soft_errors>
+                        <sro_tracking_job translate="label">
+                            <label>Ativar Monitoramento das Encomendas</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>270</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Ao ativar o monitoramento, os pedidos na situação Pedido em Transporte são rastreados regularmente. Toda movimentação fica registrada nos comentários da entrega. Pedidos em situações adversas são classificados como Dificuldade de Entrega, mas continuam sendo monitorados. Pedidos entregues são classificados como Transação Concluída, e deixam de ser monitorados. O cliente é notificado via e-mail, em eventos que necessitam sua atenção, como "Saiu para entrega", "Aguardando retirada", entre outros. Somente pedidos com código de rastreamento podem ser monitorados. Somente um rastreador (o primeiro da lista) é monitorado em cada entrega.</comment>
+                        </sro_tracking_job>
                         <sort_order translate="label">
                             <label>Ordenar Por</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>270</sort_order>
+                            <sort_order>300</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>


### PR DESCRIPTION
Adicionada mais uma opção de configuração pelo backend. Agora é possível ativar/desativar o monitoramento das entregas. Mais detalhes sobre o monitoramento na PR #101.