### PR TITLE
Corrige timeout na requisição SOAP

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -604,7 +604,16 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
         );
 
         try {
-            $client = new SoapClient($this->getConfigData('url_sro_correios'));
+            $client = new SoapClient($this->getConfigData('url_sro_correios'),array(
+                'stream_context'=>stream_context_create(
+                    array('http'=>
+                        array(
+                            'protocol_version'=>'1.1',
+                            'header' => 'Connection: Close'
+                        )
+                    )
+                )
+            ));
             $response = $client->buscaEventos($params);
             if (empty($response)) {
                 throw new Exception("Empty response");

--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -604,16 +604,18 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
         );
 
         try {
-            $client = new SoapClient($this->getConfigData('url_sro_correios'),array(
-                'stream_context'=>stream_context_create(
-                    array('http'=>
-                        array(
-                            'protocol_version'=>'1.1',
-                            'header' => 'Connection: Close'
+            $client = new SoapClient($this->getConfigData('url_sro_correios'),
+                array(
+                    'stream_context'=>stream_context_create(
+                        array('http'=>
+                            array(
+                                'protocol_version'=>'1.1',
+                                'header' => 'Connection: Close'
+                            )
                         )
                     )
                 )
-            ));
+            );
             $response = $client->buscaEventos($params);
             if (empty($response)) {
                 throw new Exception("Empty response");

--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -604,7 +604,8 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
         );
 
         try {
-            $client = new SoapClient($this->getConfigData('url_sro_correios'),
+            $client = new SoapClient(
+                $this->getConfigData('url_sro_correios'),
                 array(
                     'stream_context'=>stream_context_create(
                         array('http'=>


### PR DESCRIPTION
Closes #204, #205 

Ajusta o cabeçalho da requisição SOAP com o _stream_context_ para fechar a conexão após o retorno.

Testado com **PHP 7.0.16** e **nginx 1.11.12**