### PR TITLE
Fixes Undefined class constant 'ORDER_SHIPPED_STATUS' no update

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.5.0-4.6.0.php
+++ b/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.5.0-4.6.0.php
@@ -17,13 +17,13 @@ $installer = $this;
 $installer->startSetup();
 
 $status = Mage::getModel('sales/order_status');
-$status->setStatus(PedroTeixeira_Correios_Model_Sro::ORDER_SHIPPED_STATUS)
+$status->setStatus(PedroTeixeira_Correios_Model_Sro_Object::ORDER_SHIPPED_STATUS)
     ->setLabel('Pedido em Transporte')
     ->assignState(Mage_Sales_Model_Order::STATE_COMPLETE)
     ->save();
 
 $status = Mage::getModel('sales/order_status');
-$status->setStatus(PedroTeixeira_Correios_Model_Sro::ORDER_WARNED_STATUS)
+$status->setStatus(PedroTeixeira_Correios_Model_Sro_Object::ORDER_WARNED_STATUS)
     ->setLabel('Dificuldade de Entrega')
     ->assignState(Mage_Sales_Model_Order::STATE_COMPLETE)
     ->save();


### PR DESCRIPTION
Ao executar o update do módulo tive o problema: 
Fatal error: Uncaught Error: Undefined class constant 'ORDER_SHIPPED_STATUS' in /Users/martins/www/babycool/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.5.0-4.6.0.php on line 20
( ! ) Error: Undefined class constant 'ORDER_SHIPPED_STATUS' in /Users/martins/www/babycool/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.5.0-4.6.0.php on line 20

Este pull request corrige o problema com base na solução apresentada no #364