### PR TITLE
Corrige warning (#436)

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -383,7 +383,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
                     sprintf(
                         $this->getConfigData('msgprazo'),
                         $shippingData,
-                        (int) ($correiosDelivery + $this->getConfigData('add_prazo') + $this->_postingDays)
+                        (int) ($correiosDelivery + (int) $this->getConfigData('add_prazo') + $this->_postingDays)
                     )
                 );
             }


### PR DESCRIPTION
Evita que a mensagem de erro ocorra quando o add_prazo for nulo, convertendo o número em inteiro
Fixes #436 